### PR TITLE
Change from bash to sh

### DIFF
--- a/git.c
+++ b/git.c
@@ -9,7 +9,7 @@
 
 int main(int argc, char **argv)
 {
-    char buf[4000] = "C:/cygwin64/bin/bash -c 'git-wrapper";
+    char buf[4000] = "C:/cygwin64/bin/sh -c 'git-wrapper";
     int rest = sizeof(buf) - strlen(buf) - 2; /* 2 for "'\0" */
 
     for (int i = 1; i < argc; i++) {


### PR DESCRIPTION
vscode likes to run `git rev-parse --symbolic-full-name master@{u}`, and the `{}`s get consumed by `bash` but not by `sh`.  So this version seems to work better in practice for me.