### PR TITLE
Modify wrap output to be able to handle multiple lines

### DIFF
--- a/git-wrapper
+++ b/git-wrapper
@@ -19,7 +19,7 @@ if [ $wrap_output ]; then
         elif [ "$a[1]" = '-' ]; then
             echo $a
         else
-            cygpath -w "$a"
+            cygpath -w "${(@f)a}"
         fi
     else
         x=$?


### PR DESCRIPTION
VS Code was displaying some warnings, I traced them back to a rev-parse command that outputs multiple paths, the wrapper script didn't handle this properly

Before:
```
$ git-wrapper rev-parse --git-dir --git-common-dir
.git.git
```

After:
```
$ git-wrapper rev-parse --git-dir --git-common-dir
.git
.git
```
