### PR TITLE
Fixing issue: VS Code throwing ENOENT. rev-parse can be in any position.

### DIFF
--- a/git-wrapper
+++ b/git-wrapper
@@ -6,8 +6,8 @@ for ((i = 1; i <= $#; i++)); do
     if [ -z "$a" ]; then
         argv[i]=()
         ((i--))
-    elif [ "$a" = 'rev-parse' -a $i = 1 ]; then
-        argv[1]="$a"
+    elif [ "$a" = 'rev-parse' ]; then
+        argv[i]="$a"
         wrap_output=yes
     elif [ "$a[1]" != '-' ]; then 
         argv[i]=`cygpath -u "$a"`


### PR DESCRIPTION
I was getting the same error described here: https://github.com/gitkraken/vscode-gitlens/issues/965. The suggested changes fix the issue.